### PR TITLE
Fix partition persist attribute on webview

### DIFF
--- a/src/js/browser.js
+++ b/src/js/browser.js
@@ -161,7 +161,7 @@ $(function(){
        right:0,
        bottom:0
      })
-     .attr('partition','persistant:kiosk')
+     .attr('partition','persist:kiosk')
      .on('exit',onEnded)
      .on('unresponsive',onEnded)
      .on('loadabort',function(e){if(e.isTopLevel) onEnded(e); })


### PR DESCRIPTION
fixing partition persist attribute on webview.

It should be "persist:kiosk" not "persistant:kiosk"

ref: https://developer.chrome.com/apps/tags/webview#partition

fixes issues with localstorage, indexeddb, image/file caching, etc. being wiped every time the kiosk app was closed.