### PR TITLE
Adding Reset Cache on Save option

### DIFF
--- a/src/js/browser.js
+++ b/src/js/browser.js
@@ -15,6 +15,7 @@ $(function(){
   var disabledrag = false;
   var disabletouchhighlight = false;
   var disableselection = false;
+  var resetcache = false;
 
   function updateSchedule(){
     $.getJSON(scheduleURL, function(s) {
@@ -123,6 +124,7 @@ $(function(){
      disabledrag = data.disabledrag ? true : false;
      disabletouchhighlight = data.disabletouchhighlight ? true : false;
      disableselection = data.disableselection ? true : false;
+     resetcache = data.resetcache ? true : false;
 
      reset = data.reset && parseFloat(data.reset) > 0 ? parseFloat(data.reset) : false;
 
@@ -150,8 +152,8 @@ $(function(){
   }
 
   function loadContent(){
-     active(); //we should reset the active on load content as well
-    $('<webview id="browser"/>')
+    active(); //we should reset the active on load content as well
+    var webview = $('<webview id="browser"/>')
      .css({
        width:'100%',
        height:'100%',
@@ -207,7 +209,22 @@ $(function(){
      })
      .attr('src',currentURL)
      .prependTo('body');
-
+     if(resetcache) {
+       chrome.storage.local.remove('resetcache');
+       resetcache = false;
+       var clearDataType = {
+         appcache: true,
+         cache: true, //remove entire cache
+         cookies: true,
+         fileSystems: true,
+         indexedDB: true,
+         localStorage: true,
+         webSQL: true,
+       };
+       webview[0].clearData({since: 0}, clearDataType, function() {
+         chrome.runtime.reload();
+       });
+     }
   }
 
   function onEnded(event){

--- a/src/js/setup.js
+++ b/src/js/setup.js
@@ -138,6 +138,7 @@ $(function(){
     var remoteschedule = $("#remote-schedule").is(':checked');
     var remotescheduleurl = $("#remote-schedule-url").val();
     var schedulepollinterval = parseFloat($('#schedule-poll-interval').val()) ? parseFloat($('#schedule-poll-interval').val()) : DEFAULT_SCHEDULE_POLL_INTERVAL;
+    var resetcache = $('#reset-cache').is(':checked');
 
     if(reset){
       var reset = parseFloat($('#resetinterval').val());
@@ -227,6 +228,8 @@ $(function(){
       else chrome.storage.local.remove('disabletouchhighlight');
       if(disableselection) chrome.storage.local.set({'disableselection':disableselection});
       else chrome.storage.local.remove('disableselection');
+      if(resetcache) chrome.storage.local.set({'resetcache': resetcache});
+      else chrome.storage.local.remove('resetcache');
       chrome.storage.local.set({'url':url});
       chrome.runtime.reload();
     }

--- a/src/windows/setup.html
+++ b/src/windows/setup.html
@@ -171,13 +171,22 @@
            <label>minutes</label>
          </div>
         </div>
-
+        <div class="row">
+          <div class="col s12">
+            <h4>Cache</h4>
+          </div>
+        </div>
+        <div class="row">
+          <div class="col s6">
+            <input id="reset-cache" type="checkbox">
+            <label for="reset-cache">Reset Cache on Save?</label>
+          </div>
+        </div>
         <div class="row">
           <div class="col s12">
             <p><a class="btn-large waves-effect" id="save">Save</a></p>
           </div>
         </div>
-
       </div>
   </body>
 </html>


### PR DESCRIPTION
Added check box option to "Reset cache on save" when checked it tells the webview to dump all cache, local storage, indexedDB, webSQL, etc and reload.  Important for being able to force the kiosk to update information being saved locally.

checkbox unchecks after reset occurs.